### PR TITLE
[FIX] Add closing li to layouts/_default/terms.html

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
   <h1>{{ .Title }}</h1>
   <ul>
     {{ range $key, $value := .Data.Terms }}
-      <li><a href="{{ $key | urlize }}">{{ $key }}</a> {{ len $value }}
+      <li><a href="{{ $key | urlize }}">{{ $key }}</a> {{ len $value }}</li>
     {{ end }}
   </ul>
 {{ end }}


### PR DESCRIPTION
Hey there,

while looking at the source of your Theme I recognized a missing closing `li`-Tag inside `layouts/_default/terms.html`. I decided to quickly fix it. :) 

Great, clean theme. It's a nice starting point for looking around when developing a Hugo Theme. 