### PR TITLE
Make it possible to replace the accent color hack.css uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ SectionPagesMenu = "main" # Enable menu system for lazy bloggers
   author = "" # Optional, controls author name display on posts
   show_menu = false # Optional, set false to disable menu entirely
   powered_by = true # Optional, set false to disable credits
+  accent_color = "#ff00ff" # Optional, replace the pink accent color
 
   [params.seo]
     google_verify = "" # Optional, Google verification code

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,9 +22,9 @@
       <link rel="next" href="{{ .Params.next }}">
     {{ end }}
     {{ partial "favicon" . }}
-    {{ partial "critical-vendor.css" }}
-    {{ partial "critical-theme.css" }}
-    {{ partial "critical-custom.css" }}
+    {{ partial "critical-vendor.css" . }}
+    {{ partial "critical-theme.css" . }}
+    {{ partial "critical-custom.css" . }}
   </head>
   <body class="hack dark main container">
     <header>{{ block "header" . }}{{ end }}</header>

--- a/layouts/partials/critical-theme.css.html
+++ b/layouts/partials/critical-theme.css.html
@@ -22,7 +22,7 @@
     padding: 20px 10px;
   }
   nav a.active {
-    background-color: #ff2e88;
+    background-color: {{ with .Site.Params.accent_color }}{{ . }}{{ else }}#ff2e88{{ end }};
     color: #fff;
   }
   html {
@@ -40,4 +40,14 @@
       max-width: 50rem;
     }
   }
+
+  {{ with .Site.Params.accent_color }}
+    a {
+      color: {{ . }};
+      border-bottom: {{ . }};
+    }
+    a:hover {
+      background-color: {{ . }};
+    }
+  {{ end }}
 </style>


### PR DESCRIPTION
This was originally an experiment, but I'll probably end up using it for my site and I figured it might be useful for other people as well... it makes it possible to replace the pink accent color uses for anchor tags.

If you specify accent_color in the params, that will be used in place of `#ff2e88`, otherwise it will use the original color.

It does mess with syntax highlighting when editing the css template files, but I'm not sure if there's a way around that.