### PR TITLE
Only try to use images if some are defined

### DIFF
--- a/layouts/partials/meta/ogimage-maybe.html
+++ b/layouts/partials/meta/ogimage-maybe.html
@@ -2,12 +2,12 @@
   Hack to allow generic site image for Nodes until supported
   by the Hugo internal opengraph template.
 */}}-->
-{{ if .IsNode }}
-  <meta property="og:image" content="{{ index .Site.Params.images 0 }}">
+{{ if and (.IsNode) (.Params.images) }}
+  <meta property="og:image" content="{{ index .Params.images 0 }}">
 {{ end }}
 <!-- {{/*
   Fallback to site image if not overriden at Page level
 */}}-->
-{{ if and (.IsPage) (not .Params.images) }}
+{{ if and (.IsPage) (not .Params.images) (.Site.Params.images) }}
   <meta property="og:image" content="{{ index .Site.Params.images 0 }}">
 {{ end }}


### PR DESCRIPTION
Some of the logic in this didn't look quite right and ends up causing errors if no images are defined:

```
ERROR 2017/02/08 13:31:58 theme/partials/meta/ogimage-maybe.html template: theme/partials/meta/ogimage-maybe.html:12:40: executing "theme/partials/meta/ogimage-maybe.html" at <index .Site.Params.i...>: error calling index: index of untyped nil
ERROR 2017/02/08 13:31:58 theme/partials/meta/ogimage-maybe.html template: theme/partials/meta/ogimage-maybe.html:6:40: executing "theme/partials/meta/ogimage-maybe.html" at <index .Site.Params.i...>: error calling index: index of untyped nil
```