### PR TITLE
Pagination problems

### DIFF
--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,5 +1,6 @@
 <nav>
   <p>
+    <!-- This is just to be able PR the comment -->
     {{if .Paginator.HasPrev }}
       <a href="{{ .Paginator.Prev.URL }}">&laquo; Previous</a> |
     {{ end }}


### PR DESCRIPTION
This file (I think it is the right fil) has problems. It is not paginating `categories` entries right, and I assume it will not paginate `tags` right either. See [example](https://collantes.us/categories/personal/). There are only 12 entries within that category.