### PR TITLE
Added Meta keywords, new conditions, norton safeweb verification

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,19 @@
     {{ with .Description }}
       <meta name="description" content="{{ . }}">
     {{ end }}
+    {{ if and (not (eq .Site.Params.description .Description)) (eq .Description "") }}
+      <meta name="description" content="{{ .Site.Params.Description }}">
+    {{ end }}
+    {{ with .Keywords }}
+      {{ $list := (.Keywords) }}
+      {{ $len := (len $list) }}
+      <meta name="keywords" content="{{ range $index, $element := $list }}{{ . }}{{ if not (eq (add $index 1) $len) }},{{ end }}{{ end }}" />
+    {{ end }}
+    {{ if and (not (eq .Site.Params.keywords .Keywords)) (not (.Keywords)) }}
+      {{ $list := (.Site.Params.keywords) }}
+      {{ $len := (len $list) }}
+      <meta name="keywords" content="{{ range $index, $element := $list }}{{ . }}{{ if not (eq (add $index 1) $len) }},{{ end }}{{ end }}" />
+    {{ end }}
     {{ $default_noindex_kinds := slice "section" "taxonomy" "taxonomyTerm" }}
     {{ $noindex_kinds := .Site.Params.noindex_kinds | default $default_noindex_kinds }}
     {{ $is_noindex_true := and (isset .Params "noindex") .Params.noindex }}

--- a/layouts/partials/site-verification.html
+++ b/layouts/partials/site-verification.html
@@ -10,3 +10,6 @@
 {{ if .Site.Params.seo.webmaster_verifications.yandex }}
   <meta name="yandex-verification" content="{{ .Site.Params.seo.webmaster_verifications.yandex }}">
 {{ end }}
+{{ if .Site.Params.seo.webmaster_verifications.norton }}
+  <meta name="norton-safeweb-site-verification" content="{{ .Site.Params.seo.webmaster_verifications.norton }}" />
+{{ end }}


### PR DESCRIPTION
- Added Meta Keywords (with Keywords on pages and site)
- Added conditions: if there is no description (or keywords) on page, it will use Site.Params.description (or keywords)
- Added norton safeweb verification ** i didn't remove it because norton is pushing search engines for safe website checks. I guess it can be important :) **