### PR TITLE
Add optional license footer

### DIFF
--- a/layouts/partials/powered-by.html
+++ b/layouts/partials/powered-by.html
@@ -4,5 +4,15 @@
     <a target="_blank" rel="noopener" href="https://comfusion.github.io/after-dark/">After Dark</a>
     for
     <a target="_blank" rel="noopener" href="https://gohugo.io/">Hugo</a>.
+    {{ if isset .Site.Params "license" }}
+      <br />
+      If not stated otherwise, the content is released unter the 
+        {{ if isset .Site.Params "license_url" }}
+          <a href="{{ .Site.Params.license_url }}">{{ .Site.Params.license }}</a>
+        {{ else }}
+          {{ .Site.Params.license }}
+        {{ end }}
+      license.
+    {{ end }}
   </p>
 {{ end }}

--- a/layouts/partials/powered-by.html
+++ b/layouts/partials/powered-by.html
@@ -8,7 +8,7 @@
       <br />
       If not stated otherwise, the content is released unter the 
         {{ if isset .Site.Params "license_url" }}
-          <a href="{{ .Site.Params.license_url }}">{{ .Site.Params.license }}</a>
+          <a target="_blank" rel="noopener" href="{{ .Site.Params.license_url }}">{{ .Site.Params.license }}</a>
         {{ else }}
           {{ .Site.Params.license }}
         {{ end }}


### PR DESCRIPTION
By setting the parameters `license` and/or `license_url` one can add license information to the footer.
If only `license` is set, the output will be without a link, else the license links to the file behind `license_url`