### PR TITLE
Remove duplicate descriptor from post image srcset

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -24,7 +24,7 @@
           src="{{ $image600.RelPermalink }}"
           data-sizes="auto"
           data-src="{{ $image1200.RelPermalink }}"
-          data-srcset="{{ $image600.RelPermalink }} 600w, {{ $image900.RelPermalink }} 900w, {{ $image900.RelPermalink }} 900w, {{ $image1200.RelPermalink }} 1200w, {{ $image1600.RelPermalink }} 1600w"
+          data-srcset="{{ $image600.RelPermalink }} 600w, {{ $image900.RelPermalink }} 900w, {{ $image1200.RelPermalink }} 1200w, {{ $image1600.RelPermalink }} 1600w"
         >
       {{ end }}
     </header>


### PR DESCRIPTION
I've noticed a duplicate descriptor in post image's srcset. MDN seems to agree that this is invalid: [MDN &lt;img&gt; reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).